### PR TITLE
Sample code in plugin Javascript was causing errors

### DIFF
--- a/www/appsflyer.js
+++ b/www/appsflyer.js
@@ -58,9 +58,12 @@ if(!window.CustomEvent) {
 	});
 }(window));
 
+/*
+Example Usage:
+
 document.addEventListener("deviceready", function(){
     var args = [];
-    var devKey = "xxXXXXXxXxXXXXxXXxxxx8";  // your AppsFlyer devKey
+    var devKey = "xxXXXXXxXxXXXXxXXxxxxx";  // your AppsFlyer devKey
     args.push(devKey);
     var userAgent = window.navigator.userAgent.toLowerCase();
                           
@@ -70,4 +73,4 @@ document.addEventListener("deviceready", function(){
     }
 	window.plugins.appsFlyer.initSdk(args);
 }, false);
-
+*/


### PR DESCRIPTION
The usage example somehow ended up at the bottom of the plugin Javascript file. This was be executed immediately on launch of my Cordova application and was causing errors because it is using fake data. I commented out this example code (which clearly should not be there), and make the real call from my Cordova app using an actual dev key and app ID and everything works fine.