### PR TITLE
Add now required abstract method to avoid compilation failure on android

### DIFF
--- a/platform/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
+++ b/platform/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
@@ -73,6 +73,11 @@ public class AppsFlyerPlugin extends CordovaPlugin {
 				// TODO Auto-generated method stub
 				
 			}
+			
+			@Override
+			public void onAttributionFailure(String errorMessage) {
+				//Added this to avoid compilation failure
+			}
 
 			@Override
 			public void onInstallConversionDataLoaded(Map<String, String> conversionData) {


### PR DESCRIPTION
Recently started getting build failures on our android branch with the appsflyer phonegap plugin installed. This change allows compilation to succeed.