### PR TITLE
Reduce dependencies from playservices to gms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,57 @@
 
-# PhoneGap AppsFlyer plugin for Android and iOS. 
+# Cordova / PhoneGap AppsFlyer Plugin for Android and iOS.
 
-Built against Phonegap >= 3.3.x.
-## PhoneGap Build ##
-Add the following line to your config xml:
+
+## Documentation
+- [Installation](#installation)
+	- [Manual Installation](#manual-installation)
+	- [Phone Gap Build](#phonegap-build)  
+- [Usage API](#usage-api)
+
+**Note:** integrated AppsFlyer SDK has restrictions for iOS archs (armv7, arm64, **not** _armv7s_)
+
+
+## Installation
+
+Using the reference to GitHub repository:
+
+	cordova plugin add https://github.com/DevDmitryHub/cordova-plugin-appsflyer.git
+
+Using plugin name (Cordova v.5+):
+
+	cordova plugin add cordova-plugin-appsflyer
+
+
+For old Cordova versions you should add reference to the plugin script file. 
+Then reference `appsflyer.js` in `index.html`, after `cordova.js`/`phonegap.js`.
+Mind the path:
+
+```html
+<script type="text/javascript" src="js/plugins/appsflyer.js"></script>
 ```
+
+### Manual Installation
+
+For more details about manual installation see wiki page [Manual Installation](https://github.com/DevDmitryHub/cordova-plugin-appsflyer/wiki/Manual-installation) or use author's [page](https://github.com/AppsFlyerSDK/PhoneGap#manual-installation).
+
+### PhoneGap Build
+Built against Phonegap >= 3.3.x.
+
+Add the following line to your config xml:
+
+```xml
 <gap:plugin name="com.appsflyer.phonegap.plugins.appsflyer" version="1.0.1" />
 ```
-Add following lines to your code to be able to initialize tracking with your own AppsFlyer dev key:
-```javascript
-document.addEventListener("deviceready", function(){
-    var args = [];
-    var devKey = "xxXXXXXxXxXXXXxXXxxxx8";   // your AppsFlyer devKey
-    args.push(devKey);
-    var userAgent = window.navigator.userAgent.toLowerCase();
-                          
-    if (/iphone|ipad|ipod/.test( userAgent )) {
-        var appId = "123456789";            // your ios app id in app store
-        args.push(appId);
-    }
-	window.plugins.appsFlyer.initSdk(args);
-}, false);
-```
 
-## Installation using CLI:
-```
-$ cordova plugin add https://github.com/AppsFlyerSDK/PhoneGap.git
-```
-Then reference `appsflyer.js` in `index.html`, after `cordova.js`/`phonegap.js`. Mind the path:
-```html
-<script type="text/javascript" src="js/plugins/appsflyer.js"></script>
-```
-## Manual installation:
-1\. Add the following xml to your `config.xml` in the root directory of your `www` folder:
-```xml
-<!-- for iOS -->
-<feature name="AppsFlyerPlugin">
-  <param name="ios-package" value="AppsFlyerPlugin" />
-</feature>
-```
-```xml
-<!-- for Android -->
-<feature name="AppsFlyerPlugin">
-  <param name="android-package" value="com.appsflyer.cordova.plugin.AppsFlyerPlugin" />
-</feature>
-```
-2\. For Android, add the following xml to your `AndroidManifest.xml`:
-```xml
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-<uses-permission android:name="android.permission.READ_PHONE_STATE" />
-```
-3\. Copy appsflyer.js to `www/js/plugins` and reference it in `index.html`:
-```html
-<script type="text/javascript" src="js/plugins/appsflyer.js"></script>
-```
-4\. Download the source files and copy them to your project.
-
-iOS: Copy `AppsFlyerPlugin.h`, `AppsFlyerPlugin.m`, `AppsFlyerTracker.h` and `libAppsFlyerLib.a` to `platforms/ios/<ProjectName>/Plugins`
-
-Android: Copy `AppsFlyerPlugin.java` to `platforms/android/src/com/appsflyer/cordova/plugins` (create the folders)
-        
-## Usage:
+## Usage API
+ 
 
 #### 1\. Set your App_ID (iOS only), Dev_Key and enable AppsFlyer to detect installations, sessions (app opens), and updates.  
-**Note: ** *This is the minimum requirement to start tracking your app installs and it's already implemented in this plugin. You **_MUST_** modify this call and provide:  *
+**Note:** *This is the minimum requirement to start tracking your app installs and it's already implemented in this plugin. You **_MUST_** modify this call and provide:*
+
 - *devKey* - Your application devKey provided by AppsFlyer.
 - *appId*  - **For iOS only.** Your iTunes application id.
+
 ```javascript
 document.addEventListener("deviceready", function(){
     var args = [];

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ var getUserIdCallbackFn = function(id) {
 }
 window.plugins.appsFlyer.getAppsFlyerUID(getUserIdCallbackFn);
 ```
-#### 6\. Accessing AppsFlyer Attribution / Conversion Data from the SDK (Deferred 
-Deep-linking). Read more: [Android](http://support.appsflyer.com/entries/69796693-Accessing-AppsFlyer-Attribution-Conversion-Data-from-the-SDK-Deferred-Deep-linking-), [iOS](http://support.appsflyer.com/entries/22904293-Testing-AppsFlyer-iOS-SDK-Integration-Before-Submitting-to-the-App-Store-)  
+#### 6\. Accessing AppsFlyer Attribution / Conversion Data from the SDK (Deferred Deep-linking). 
+Read more: [Android](http://support.appsflyer.com/entries/69796693-Accessing-AppsFlyer-Attribution-Conversion-Data-from-the-SDK-Deferred-Deep-linking-), [iOS](http://support.appsflyer.com/entries/22904293-Testing-AppsFlyer-iOS-SDK-Integration-Before-Submitting-to-the-App-Store-)  
 **Note:** AppsFlyer plugin will fire `onInstallConversionDataLoaded` event with attribution data. You must implement listener to receive the data.
 ###### Example:
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cordova-plugin-appsflyer",
+  "version": "3.1",
+  "description": "Cordova plugin for integration with AppsFlyer SDK. It's a fork of the official version from AppsFlyer.",
+  "cordova": {
+    "id": "cordova-plugin-appsflyer",
+    "platforms": [
+      "android",
+      "ios",
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DevDmitryHub/cordova-plugin-appsflyer"
+  },
+  "keywords": [
+    "cordova",
+    "appsflyer",
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios",
+  ],
+  "author": "DevDmitryHub",
+  "license": "Apache 2.0"
+  "homepage": "https://github.com/DevDmitryHub/cordova-plugin-appsflyer#readme"
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "cordova-ios"
   ],
   "author": "DevDmitryHub",
-  "license": "Apache 2.0"
+  "license": "Apache 2.0",
   "homepage": "https://github.com/DevDmitryHub/cordova-plugin-appsflyer#readme"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "id": "cordova-plugin-appsflyer",
     "platforms": [
       "android",
-      "ios",
+      "ios"
     ]
   },
   "repository": {
@@ -18,7 +18,7 @@
     "appsflyer",
     "ecosystem:cordova",
     "cordova-android",
-    "cordova-ios",
+    "cordova-ios"
   ],
   "author": "DevDmitryHub",
   "license": "Apache 2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appsflyer",
-  "version": "3.1",
+  "version": "3.3.1",
   "description": "Cordova plugin for integration with AppsFlyer SDK. It's a fork of the official version from AppsFlyer.",
   "cordova": {
     "id": "cordova-plugin-appsflyer",

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
         <source-file src="platform/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java" target-dir="src/com/appsflyer/cordova/plugin" />
         <source-file src="platform/android/libs/AF-Android-SDK-v3.3.0.jar" target-dir="libs"/>
 
-        <dependency id="com.google.playservices" version="22.0.0" />
+        <framework src="com.google.android.gms:play-services-ads:+" />
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-appsflyer"
-        version="3.1">
+        version="3.3.1">
     <name>AppsFlyer</name>
     <description>Cordova plugin for integration with AppsFlyer SDK. It's a fork of the official version from AppsFlyer.</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,22 +20,25 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="com.appsflyer.phonegap.plugins.appsflyer"
-        version="3.0">
+        id="cordova-plugin-appsflyer"
+        version="3.1">
     <name>AppsFlyer</name>
-    <description>Cordova AppsFlyer Plugin</description>
+    <description>Cordova plugin for integration with AppsFlyer SDK. It's a fork of the official version from AppsFlyer.</description>
     <license>Apache 2.0</license>
     <keywords>cordova,appsflyer</keywords>
-    <repo>https://github.com/AppsFlyerSDK/PhoneGap.git</repo>
+    <repo>https://github.com/DevDmitryHub/cordova-plugin-appsflyer.git</repo>
+
     <engines>
         <engine name="cordova" version=">=3.3.0"/>
     </engines>
 
+	<js-module src="www/appsflyer.js" name="appsflyer">
+		<clobbers target="window.plugins.appsFlyer" />
+	</js-module>
+
+
     <!-- android -->
     <platform name="android">
-        <js-module src="www/appsflyer.js" name="appsflyer">
-            <clobbers target="window.plugins.appsFlyer" />
-        </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AppsFlyerPlugin">
                 <param name="android-package" value="com.appsflyer.cordova.plugin.AppsFlyerPlugin"/>
@@ -61,10 +64,7 @@
     </platform>
 
     <!-- ios -->
-    <platform name="ios">
-        <js-module src="www/appsflyer.js" name="appsflyer">
-            <clobbers target="window.plugins.appsFlyer" />
-        </js-module>
+    <platform name="ios">    
         <config-file target="config.xml" parent="/*">
             <feature name="AppsFlyerPlugin">
                 <param name="ios-package" value="AppsFlyerPlugin" />


### PR DESCRIPTION
Better reduce depencency from _com.google.playservice_ to _com.google.android.gms:play-services-ads_.
It allows avoid :zap: the error about duplicate _.dex_ files on build mobile applications for _Android_ platform.