### PR TITLE
Reduce dependencies from playservices to gms

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
         <source-file src="platform/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java" target-dir="src/com/appsflyer/cordova/plugin" />
         <source-file src="platform/android/libs/AF-Android-SDK-v3.3.0.jar" target-dir="libs"/>
 
-        <dependency id="com.google.playservices" version="22.0.0" />
+        <framework src="com.google.android.gms:play-services-ads:+" />
     </platform>
 
     <!-- ios -->


### PR DESCRIPTION
Better reduce depencency from _com.google.playservice_ to _com.google.android.gms:play-services-ads_.
It allows avoid :zap: the error about duplicate _.dex_ files on build mobile applications for _Android_ platform.