### PR TITLE
Updated the com.google.playservices dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
         <source-file src="platform/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java" target-dir="src/com/appsflyer/cordova/plugin" />
         <source-file src="platform/android/libs/AF-Android-SDK-v3.3.0.jar" target-dir="libs"/>
 
-        <dependency id="com.google.playservices" version="22.0.0" />
+        <dependency id="com.google.playservices" version="23.0.0" />
     </platform>
 
     <!-- ios -->


### PR DESCRIPTION
Was getting this error - 
Failed to install 'com.appsflyer.phonegap.plugins.appsflyer':Error: Expected plugin to have ID "com.google.playservices" but got "cordova-plugin-googleplayservices".
WARNING: com.google.playservices has been renamed to cordova-plugin-googleplayservices. You may not be getting the latest version! 

If we update the dependency then the package wont be renamed and the first error would be resolved.